### PR TITLE
Run migrations before application starts.

### DIFF
--- a/lib/mpnetwork/release_tasks.ex
+++ b/lib/mpnetwork/release_tasks.ex
@@ -1,0 +1,70 @@
+# copied and modified from 
+# https://github.com/bitwalker/distillery/blob/master/docs/Running%20Migrations.md
+defmodule Mpnetwork.ReleaseTasks do
+
+  @start_apps [
+    :crypto,
+    :ssl,
+    :postgrex,
+    :ecto
+  ]
+
+  def myapp, do: :mpnetwork
+
+  def repos, do: Application.get_env(myapp(), :ecto_repos, [])
+
+  def seed do
+    me = myapp()
+
+    IO.puts "Loading #{me}.."
+    # Load the code for myapp, but don't start it
+    :ok = Application.load(me)
+
+    IO.puts "Starting dependencies.."
+    # Start apps necessary for executing migrations
+    Enum.each(@start_apps, &Application.ensure_all_started/1)
+
+    # Start the Repo(s) for myapp
+    IO.puts "Starting repos.."
+    Enum.each(repos(), &(&1.start_link(pool_size: 1)))
+
+    # Run migrations
+    migrate()
+
+    # Run seed script
+    # Enum.each(repos(), &run_seeds_for/1)
+
+    # Signal shutdown
+    IO.puts "Success!"
+    :init.stop()
+  end
+
+  def migrate, do: Enum.each(repos(), &run_migrations_for/1)
+
+  def priv_dir(app), do: "#{:code.priv_dir(app)}"
+
+  defp run_migrations_for(repo) do
+    app = Keyword.get(repo.config, :otp_app)
+    IO.puts "Running migrations for #{app}"
+    Ecto.Migrator.run(repo, migrations_path(repo), :up, all: true)
+  end
+
+  def run_seeds_for(repo) do
+    # Run the seed script if it exists
+    seed_script = seeds_path(repo)
+    if File.exists?(seed_script) do
+      IO.puts "Running seed script.."
+      Code.eval_file(seed_script)
+    end
+  end
+
+  def migrations_path(repo), do: priv_path_for(repo, "migrations")
+
+  def seeds_path(repo), do: priv_path_for(repo, "seeds.exs")
+
+  def priv_path_for(repo, filename) do
+    app = Keyword.get(repo.config, :otp_app)
+    repo_underscore = repo |> Module.split |> List.last |> Macro.underscore
+    Path.join([priv_dir(app), repo_underscore, filename])
+  end
+end

--- a/rel/commands/migrate.sh
+++ b/rel/commands/migrate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$RELEASE_ROOT_DIR/bin/mpnetwork command Elixir.Mpnetwork.ReleaseTasks seed

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -37,6 +37,7 @@ environment :prod do
   set include_erts: true
   set include_src: false
   set cookie: :"B8ZQgmmb&FehGImXOA;tF>AQ<DKkTSt.7eB}[F|[90{PMR9evUweg%tU!!OI[s~s"
+  set pre_start_hook: "rel/commands/migrate.sh"
 end
 
 # You may define one or more releases in this file.
@@ -46,6 +47,9 @@ end
 
 release :mpnetwork do
   set version: current_version(:mpnetwork)
+  set commands: [
+    "migrate": "rel/commands/migrate.sh"
+  ]
   set applications: [
     :runtime_tools
   ]


### PR DESCRIPTION
I did this by following
https://github.com/bitwalker/distillery/blob/master/docs/Running%20Migrations.md
and
https://github.com/bitwalker/distillery/blob/master/docs/Boot%20Hooks.md

I verified locally by running
```
MIX_ENV=prod mix release --env=prod
REPLACE_OS_VARS=true DATABASE_URL="postgres://postgres:postgres@localhost:5432/foo" PORT=4000 _build/prod/rel/mpnetwork/bin/mpnetwork foreground
```

Got output
```
Loading mpnetwork..
Starting dependencies..
Starting repos..
Running migrations for mpnetwork
...
Success!
```

And `curl localhost:4000` succeeded.